### PR TITLE
fix(install): 消除命令执行停顿，改为一气呵成指令流

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -230,6 +230,12 @@ function scanInvocableSkills(skillsDir) {
 
 /**
  * 根据 SKILL.md 元数据生成 command .md 内容
+ *
+ * 设计原则：
+ * - 读取 SKILL.md + 执行脚本合并为一气呵成的指令流
+ * - 禁止「先…然后…」的分步模式，避免 Claude 在步骤间停顿
+ * - 无脚本的 skill：仅读取 SKILL.md 作为知识库提供指导
+ *
  * @param {Object} meta - parseFrontmatter 返回的元数据
  * @param {string} skillRelPath - 相对于 skills/ 的路径（如 'tools/gen-docs'）
  * @param {boolean} hasScripts - 是否有可执行脚本
@@ -253,24 +259,23 @@ function generateCommandContent(meta, skillRelPath, hasScripts) {
   lines.push(`allowed-tools: ${tools}`);
   lines.push('---');
   lines.push('');
-  lines.push('## 执行指南');
-  lines.push('');
-  lines.push('先读取完整的 Skill 定义获取详细规范：');
-  lines.push('');
-  lines.push('```');
-  lines.push(skillPath);
-  lines.push('```');
 
   if (hasScripts) {
+    // ── 有脚本的 skill：读取规范 + 执行脚本，一气呵成 ──
+    lines.push('以下所有步骤一气呵成，不要在步骤间停顿等待用户输入：');
     lines.push('');
-    lines.push('然后执行：');
+    lines.push(`1. 读取规范：${skillPath}`);
+    lines.push(`2. 执行命令：\`node ~/.claude/skills/run_skill.js ${name} $ARGUMENTS\``);
+    lines.push('3. 按规范分析输出，完成后续动作');
     lines.push('');
-    lines.push('```bash');
-    lines.push(`node ~/.claude/skills/run_skill.js ${name} $ARGUMENTS`);
-    lines.push('```');
+    lines.push('全程不要停顿，不要询问是否继续。');
   } else {
+    // ── 无脚本的 skill：知识库模式 ──
+    lines.push('读取以下秘典，根据内容为用户提供专业指导：');
     lines.push('');
-    lines.push('根据秘典内容为用户提供专业指导。');
+    lines.push('```');
+    lines.push(skillPath);
+    lines.push('```');
   }
 
   lines.push('');


### PR DESCRIPTION
## Summary

- 修改 `generateCommandContent()` 生成的命令包装内容
- 将「先读取 SKILL.md…然后执行」两步分离模式改为一气呵成指令流
- 消除 Claude 在 Read/Bash 工具调用间的停顿等待用户输入问题

## Problem

PR #4 合并后，生成的命令包装使用「先…然后…」分步指令：

```
先读取完整的 Skill 定义获取详细规范：
~/.claude/skills/tools/gen-docs/SKILL.md

然后执行：
node ~/.claude/skills/run_skill.js gen-docs $ARGUMENTS
```

Claude 将两步拆成两个独立 turn，每个 turn 结束后停顿等待用户输入「继续」。

## Fix

改为有序步骤列表 + 一气呵成约束：

```
以下所有步骤一气呵成，不要在步骤间停顿等待用户输入：

1. 读取规范：~/.claude/skills/tools/gen-docs/SKILL.md
2. 执行命令：node ~/.claude/skills/run_skill.js gen-docs $ARGUMENTS
3. 按规范分析输出，完成后续动作

全程不要停顿，不要询问是否继续。
```

- ✅ 保留读取 SKILL.md（保留行为上下文如骨架填充指引）
- ✅ 保留执行 run_skill.js（保留脚本功能）
- ✅ `allowed-tools` 恢复使用 SKILL.md 中定义的工具集
- ✅ 消除步骤间停顿

## Test plan

- [x] 66/66 单元测试通过
- [x] 实际测试 `/gen-docs --force`：Claude 不再停顿，一气呵成完成读取→执行→分析