### PR TITLE
# feat(install): 目录条目展开为子级安装，支持与用户自定义 skills 共存

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -250,15 +250,13 @@ function runUninstall(tgt) {
     if (fs.existsSync(targetPath)) {
       rmSafe(targetPath);
       console.log(`  ${c.red('✘')} ${manifestLabel(entry, tgt)}`);
-      if (normalized.root !== tgt) {
-        let parent = path.dirname(targetPath);
-        while (parent !== installRoot && parent !== path.dirname(parent)) {
-          try {
-            if (fs.readdirSync(parent).length > 0) break;
-            fs.rmdirSync(parent);
-          } catch { break; }
-          parent = path.dirname(parent);
-        }
+      let parent = path.dirname(targetPath);
+      while (parent !== installRoot && parent !== path.dirname(parent)) {
+        try {
+          if (fs.readdirSync(parent).length > 0) break;
+          fs.rmdirSync(parent);
+        } catch { break; }
+        parent = path.dirname(parent);
       }
     }
   });
@@ -694,17 +692,46 @@ function installCore(tgt, selectedStyle, selectedPersona, packPlan) {
       warn(`跳过: ${src}`); return;
     }
 
-    if (fs.existsSync(destPath)) {
-      const backupPath = path.join(backupDir, rootName, dest);
-      rmSafe(backupPath);
-      copyRecursive(destPath, backupPath);
-      pushManifestEntry(manifest.backups, rootName, dest);
-      info(`备份: ${c.d(rootName === tgt ? dest : `${rootName}/${dest}`)}`);
+    let srcStat;
+    try { srcStat = fs.statSync(srcPath); } catch (e) {
+      warn(`无法读取源: ${srcPath}`); return;
     }
-    ok(rootName === tgt ? dest : `${rootName}/${dest}`);
-    rmSafe(destPath);
-    copyRecursive(srcPath, destPath);
-    pushManifestEntry(manifest.installed, rootName, dest);
+
+    if (srcStat.isDirectory()) {
+      let children;
+      try { children = fs.readdirSync(srcPath); } catch (e) {
+        warn(`无法读取目录: ${srcPath}`); return;
+      }
+      children.filter(child => !shouldSkip(child)).forEach(child => {
+        const childSrc = path.join(srcPath, child);
+        const childDest = path.join(destPath, child);
+        const childRelPath = path.posix.join(dest, child);
+
+        if (fs.existsSync(childDest)) {
+          const backupPath = path.join(backupDir, rootName, childRelPath);
+          rmSafe(backupPath);
+          copyRecursive(childDest, backupPath);
+          pushManifestEntry(manifest.backups, rootName, childRelPath);
+          info(`备份: ${c.d(rootName === tgt ? childRelPath : `${rootName}/${childRelPath}`)}`);
+        }
+        ok(rootName === tgt ? childRelPath : `${rootName}/${childRelPath}`);
+        rmSafe(childDest);
+        copyRecursive(childSrc, childDest);
+        pushManifestEntry(manifest.installed, rootName, childRelPath);
+      });
+    } else {
+      if (fs.existsSync(destPath)) {
+        const backupPath = path.join(backupDir, rootName, dest);
+        rmSafe(backupPath);
+        copyRecursive(destPath, backupPath);
+        pushManifestEntry(manifest.backups, rootName, dest);
+        info(`备份: ${c.d(rootName === tgt ? dest : `${rootName}/${dest}`)}`);
+      }
+      ok(rootName === tgt ? dest : `${rootName}/${dest}`);
+      rmSafe(destPath);
+      copyRecursive(srcPath, destPath);
+      pushManifestEntry(manifest.installed, rootName, dest);
+    }
   });
 
   pushPackReport(manifest, {

--- a/bin/uninstall.js
+++ b/bin/uninstall.js
@@ -65,10 +65,10 @@ console.log(`\n🗑️  卸载 Code Abyss v${manifest.version}...\n`);
   if (fs.existsSync(p)) {
     fs.rmSync(p, { recursive: true, force: true });
     console.log(`🗑️  删除: ${entryLabel(entry)}`);
-    if (typeof entry !== 'string' && entry.root !== manifest.target) {
-      const rootDir = path.join(os.homedir(), MANAGED_ROOTS[entry.root] || '');
-      pruneEmptyParents(path.dirname(p), rootDir);
-    }
+    const rootDir = typeof entry !== 'string'
+      ? path.join(os.homedir(), MANAGED_ROOTS[entry.root] || '')
+      : targetDir;
+    pruneEmptyParents(path.dirname(p), rootDir);
   }
 });
 


### PR DESCRIPTION
Supersedes #18

## 问题

当前 `installCore()` 将 `skills/`、`output-styles/`、`bin/lib/` 等目录视为单一整体单元：整体备份 → 删除 → 全量覆盖。这导致用户原有的自定义 skills 在安装期间被"冻结"到 `.sage-backup/` 中，只有卸载时才能恢复，无法与 Code Abyss skills 共存。

## 方案

将目录类安装条目展开为 immediate children 逐个安装，而不是整个目录替换。

**`installCore()` 改动：**

- 对每个 `filesToInstall` 条目检测 `srcPath` 是否为目录
- 目录 → `fs.readdirSync()` 枚举 children，过滤 `shouldSkip()` 后逐个安装
- 每个 child 独立备份、独立 manifest 追踪（`{root: "claude", path: "skills/domains"}` 而非 `{path: "skills"}`）
- 文件类型保持原有逻辑不变

**`runUninstall()` + `uninstall.js` 改动：**

- 移除空目录裁剪的 `normalized.root !== tgt` 守卫
- 子级安装后同域内的父目录在所有 child 被移除后形成空壳，需统一清理

## 验证

基于 `v2.1.8` (telagod/main) rebase，按最新口径全部重新验证：

| 验证项 | 结果 |
|--------|------|
| `npm run verify:skills` | 26 skills ✅ |
| `npm test -- --runInBand` | 217 passed（5 个 Windows 预置失败，非本次改动）✅ |
| Smoke tests（Claude/Codex/Gemini/OpenClaw） | 12/12 ✅ |
| 默认不生成 explicit commands | `commands/` 目录不存在 ✅ |
| 用户 skill 共存（安装前后） | 安装→卸载全周期存活 ✅ |
| `.sage-backup/manifest.json` 恢复链兼容 | install→uninstall→reinstall→uninstall 全链路正常 ✅ |

## 改动文件

| 文件 | + | - |
|------|---|---|
| `bin/install.js` | 50 | 23 |
| `bin/uninstall.js` | 4 | 1 |

## 向后兼容

- 旧版 manifest 中 `{path: "skills"}` 整目录条目仍以 `rmSafe` 删除，行为不变
- 新版 manifest 中 `{path: "skills/domains"}` 等子条目逐条删除 + 空目录裁剪
- manifest_version 保持 v2，不做版本号升级

---

> 基于 reviewer 在 #18 的反馈完整 rebase：基于 `v2.1.8` 主线，包含 OpenClaw target、runtimeRoots 支持等最新变更，按新口径重新验证。