### PR TITLE
fix(test): make install-tui driver wait for prompt markers

### DIFF
--- a/test/install-tui.test.js
+++ b/test/install-tui.test.js
@@ -8,12 +8,17 @@ const { spawn } = require('child_process');
 const projectRoot = path.join(__dirname, '..');
 const gstackFixture = path.join(__dirname, 'fixtures', 'gstack-codex-source');
 
-function runInteractiveInstall({ tmpHome, inputSteps, timeout = 8000 }) {
+function runInteractiveInstall({ tmpHome, steps, timeout = 30000, settleMs = 80 }) {
   return new Promise((resolve, reject) => {
+    const cleanEnv = { ...process.env };
+    delete cleanEnv.ANTHROPIC_API_KEY;
+    delete cleanEnv.ANTHROPIC_AUTH_TOKEN;
+    delete cleanEnv.ANTHROPIC_BASE_URL;
+
     const child = spawn(process.execPath, [path.join(projectRoot, 'bin', 'install.js')], {
       cwd: projectRoot,
       env: {
-        ...process.env,
+        ...cleanEnv,
         HOME: tmpHome,
         USERPROFILE: tmpHome,
         CODE_ABYSS_GSTACK_SOURCE: gstackFixture,
@@ -23,25 +28,49 @@ function runInteractiveInstall({ tmpHome, inputSteps, timeout = 8000 }) {
     let stdout = '';
     let stderr = '';
     let settled = false;
+    let stepIndex = 0;
+    let waitMarker = steps[0]?.waitFor || null;
 
-    child.stdout.on('data', chunk => { stdout += chunk.toString('utf8'); });
+    const fail = (message) => {
+      if (settled) return;
+      settled = true;
+      try { child.kill('SIGTERM'); } catch (_) { /* noop */ }
+      reject(new Error(`${message}\nstdout:\n${stdout}\nstderr:\n${stderr}`));
+    };
+
+    const advance = () => {
+      while (stepIndex < steps.length) {
+        const step = steps[stepIndex];
+        if (step.waitFor && !stdout.includes(step.waitFor)) {
+          waitMarker = step.waitFor;
+          return;
+        }
+        stepIndex += 1;
+        const pause = step.pauseBefore ?? settleMs;
+        const doWrite = () => { if (!settled) child.stdin.write(step.input); };
+        if (pause > 0) setTimeout(doWrite, pause); else doWrite();
+      }
+      waitMarker = null;
+    };
+
+    child.stdout.on('data', chunk => {
+      stdout += chunk.toString('utf8');
+      if (stepIndex < steps.length) advance();
+    });
     child.stderr.on('data', chunk => { stderr += chunk.toString('utf8'); });
 
-    const timers = inputSteps.map(({ delay, input }) => setTimeout(() => {
-      child.stdin.write(input);
-    }, delay));
     const killTimer = setTimeout(() => {
-      settled = true;
-      child.kill('SIGTERM');
-      reject(new Error(`interactive install timed out\nstdout:\n${stdout}\nstderr:\n${stderr}`));
+      const pending = waitMarker ? ` (waiting for marker: ${JSON.stringify(waitMarker)})` : '';
+      fail(`interactive install timed out at step ${stepIndex}/${steps.length}${pending}`);
     }, timeout);
 
     child.on('error', reject);
     child.on('close', (status) => {
-      timers.forEach(clearTimeout);
       clearTimeout(killTimer);
       if (!settled) resolve({ status, stdout, stderr });
     });
+
+    advance();
   });
 }
 
@@ -59,15 +88,16 @@ describe('interactive install TUI', () => {
   test('persona/style 使用 Tab 横向切换且只配置一次', async () => {
     const result = await runInteractiveInstall({
       tmpHome,
-      inputSteps: [
-        { delay: 300, input: ' ' },
-        { delay: 450, input: '\r' },
-        { delay: 650, input: '\r' },
-        { delay: 850, input: '\t' },
-        { delay: 1000, input: '\r' },
-        { delay: 1200, input: '\t' },
-        { delay: 1350, input: '\r' },
-        { delay: 1800, input: '\r' },
+      steps: [
+        { waitFor: '选择目标（可多选）', input: ' ' },
+        { input: '\r' },
+        { waitFor: '选择动作', input: '\r' },
+        { waitFor: '选择人格', input: '\t' },
+        { input: '\r' },
+        { waitFor: '选择输出风格', input: '\t' },
+        { input: '\r' },
+        { waitFor: '配置自定义 provider', input: 'n\r' },
+        { waitFor: '选择要安装的配置', input: '\r' },
       ],
     });
     const claudeDir = path.join(tmpHome, '.claude');
@@ -78,5 +108,5 @@ describe('interactive install TUI', () => {
     expect(result.stdout).toContain('tab/→ next');
     expect(claudeMd).toContain('文言小生');
     expect(settings.outputStyle).toBe('scholar-classic');
-  });
+  }, 45000);
 });


### PR DESCRIPTION
## Summary

Make `test/install-tui.test.js` deterministic on any host or CI runner.

- Replace fixed `setTimeout` delays with stdout marker-based waiting
- Each input is gated on its corresponding prompt text (`选择目标` / `选择动作` / `选择人格` / `选择输出风格` / `配置自定义 provider` / `选择要安装的配置`)
- Scrub `ANTHROPIC_*` env vars from the child process so the test always takes the same "no auth" path, regardless of the developer's local env
- Bump jest test timeout to 45s for safety on slow CI

## Root cause (two-part)

The previous driver fired all stdin inputs on absolute timers from spawn. Two issues combined made it flaky:

1. **Cold-start latency**. On CI the dynamic `await import('@inquirer/prompts')` adds 500ms-2s, so the first keystrokes arrived before the first prompt was ready and were silently dropped, stalling the test at the persona screen.
2. **Environment-dependent prompt count**. When the host dev has `ANTHROPIC_API_KEY` in env the installer skips the "配置自定义 provider?" confirm. CI has no such key and the extra prompt shows up — neither the original test nor the first rewrite (timeout-bump only) accounted for it.

Observed failures (same test, unrelated to PR content):
- v2.1.9 release run [25165467160](https://github.com/telagod/code-abyss/actions/runs/25165467160) — `bc6d0bc` on main
- PR #20 run [25792241806](https://github.com/telagod/code-abyss/actions/runs/25792241806)
- This PR's first attempt (raise-timeout-only) run [25793989210](https://github.com/telagod/code-abyss/actions/runs/25793989210)
- This PR's second attempt (markers, missing confirm step) run [25795801881](https://github.com/telagod/code-abyss/actions/runs/25795801881)

Marker-based waiting + env scrubbing makes the test deterministic on any host/runner.

## Validation

- `env -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN -u ANTHROPIC_BASE_URL npx jest test/install-tui.test.js --runInBand` — passed in 645ms
- `env -u ANTHROPIC_API_KEY ... npx jest --runInBand` — 23 passed, 1 skipped, 223 tests, total 4.6s
- `npm run verify:skills` — 26 skills
- CI run [25795978456](https://github.com/telagod/code-abyss/actions/runs/25795978456): `test (18/20/22)` all green

## Diff

```
test/install-tui.test.js | 70 ++++++++++++++++++++++++++++++++++++--------
1 file changed, 50 insertions(+), 20 deletions(-)
```