### PR TITLE
fix(ccstatusline): use `full` flexMode to avoid trailing truncation

### DIFF
--- a/config/ccstatusline/settings.json
+++ b/config/ccstatusline/settings.json
@@ -25,7 +25,7 @@
       { "id": "17", "type": "session-clock", "color": "brightBlack" }
     ]
   ],
-  "flexMode": "full-minus-40",
+  "flexMode": "full",
   "compactThreshold": 60,
   "colorLevel": 1,
   "inheritSeparatorColors": false,


### PR DESCRIPTION
## Summary

`config/ccstatusline/settings.json` 里的 `flexMode` 从 `full-minus-40` 改成 `full`，避免在常见终端宽度下双行预设末尾出现 `...` 截断指示。

## Root cause

ccstatusline 2.2.18 的 `flexMode` 是 Zod 枚举字段，合法值只有 3 个：

```
full | full-minus-40 | full-until-compact
```

仓库里 bundled 的双行 token/cost 预设用的是 `full-minus-40`：状态栏最多用 `(终端宽度 - 40)` 字符，给 Claude Code 右下角自带 UI 元素留 40 字符的余量。

实际跑下来这个余量太大 —— 双行预设里 `claude-opus-4-x[1m]` 一项就吃 ~20 字符，加上 token / cost / git-dir / clock，会触发 ccstatusline 自己的尾部截断逻辑，在每行末尾追加 `...`，**看起来像内容被吃掉了一截**。

## Validation

本地用 ccstatusline 2.2.18 跑了 reproduce + verify：

```bash
echo '{"model":{"display_name":"opus","id":"claude-opus-4-7"}, ...}' \
  | node ~/.npm/_npx/.../ccstatusline/dist/ccstatusline.js
```

修复前（`full-minus-40` + 双行预设）：
- 第 1 行末尾 `...`
- 用户截图显示的现象

修复后（`full` + 双行预设）：
```
opus | ↑0 ↓0 ⊡0 | 0 0.0%
code-abyss | Cost: $0.00 | Session: <1m
```
干净，无截断。

Schema 校验也过：之前如果有人误改成非法值（比如 `full-minus-20`），ccstatusline 会直接 `Failed to parse settings: ZodError` 并**把整个 settings.json 重置成 default 模板**，导致 Code Abyss 的双行预设丢失。所以这次只在 3 个合法值里选最宽松的 `full`。

## Impact

- 仅影响 `installCcstatusline` 把 bundled preset 部署到 `~/.config/ccstatusline/settings.json` 这一路径
- 新装用户：直接拿到 `flexMode: "full"`
- 已装用户：下次跑 install 才会被覆盖（installer 每次会从 bundled preset 重写本地配置）
- 无版本号 bump：cosmetic fix，没有运行时行为变更

## Diff

```
 config/ccstatusline/settings.json | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```
