### PR TITLE
ci: add npm publish automation + OpenClaw smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,3 +162,45 @@ jobs:
           test ! -e "$abyss_home/.gemini/GEMINI.md"
           test ! -e "$abyss_home/.gemini/skills"
           test ! -e "$abyss_home/.gemini/.sage-backup"
+
+  smoke-openclaw:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 20
+      - run: npm ci
+      - name: Pack npm tarball
+        shell: bash
+        run: npm pack
+      - name: Smoke install/uninstall OpenClaw target
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          pkg_tgz="$(ls code-abyss-*.tgz | head -n 1)"
+          abyss_home="$RUNNER_TEMP/abyss-home"
+          rm -rf "$abyss_home"
+          mkdir -p "$abyss_home"
+
+          export HOME="$abyss_home"
+          export USERPROFILE="$abyss_home"
+
+          npx --yes --package "./$pkg_tgz" code-abyss --target openclaw -y
+
+          test -d "$abyss_home/.openclaw/skills"
+          test -f "$abyss_home/.openclaw/workspace/AGENTS.md"
+          test -f "$abyss_home/.openclaw/workspace/SOUL.md"
+          test -f "$abyss_home/.openclaw/.sage-uninstall.js"
+          test ! -e "$abyss_home/.openclaw/commands"
+          test ! -e "$abyss_home/.openclaw/skills/gstack"
+
+          npx --yes --package "./$pkg_tgz" code-abyss --uninstall openclaw
+
+          test ! -e "$abyss_home/.openclaw/skills"
+          test ! -e "$abyss_home/.openclaw/.sage-backup"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Verify tag matches package.json version
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          pkg=$(node -p "require('./package.json').version")
+          if [ "$tag" != "$pkg" ]; then
+            echo "::error::Tag ${GITHUB_REF_NAME} (=$tag) does not match package.json version $pkg"
+            exit 1
+          fi
+          echo "Tag and package.json both at $pkg"
+
+      - name: Run tests
+        run: npm test
+
+      - name: Verify skills contract
+        run: npm run verify:skills
+
+      - name: Publish to npm
+        run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

两项 CI 自动化：

### 1. `release.yml` — npm 自动发布

订阅 `release: published` 事件。以后小宝在 GitHub 上 `gh release create v2.1.x` 之后，workflow 自动跑测试 + skills 契约 + `npm publish --provenance`，不再需要本地手动 publish。

**安全 gate**：
- `tag == package.json.version`：tag `v2.1.x` 必须对应 package.json `2.1.x`，否则 abort（防止 git tag 和 package 漂移）
- 跑完 `npm test` + `npm run verify:skills` 才 publish
- `--provenance`：在 npmjs.com 公开记录 publish 来源（GitHub Actions run），有官方 attestation
- `id-token: write` OIDC 权限（provenance 必需）
- `NPM_TOKEN` 走 repository secret，不落地

### 2. `ci.yml` — 补 OpenClaw smoke

仓库自 v2.1.8 起支持 `openclaw` target，但 CI smoke 矩阵一直只覆盖 claude/codex/gemini。这次补齐 `smoke-openclaw` job，结构与 gemini 对齐：

- Ubuntu / macOS / Windows 三平台
- 断言：`~/.openclaw/skills/`、`workspace/AGENTS.md`、`workspace/SOUL.md`、`.sage-uninstall.js`
- 反向断言：`commands/` 不存在、`skills/gstack` 不存在
- 卸载后 `.sage-backup` 清空

## Validation

本地预跑 OpenClaw 安装确认 smoke 断言全部对得上：

```
~/.openclaw/skills/run_skill.js
~/.openclaw/workspace/SOUL.md
~/.openclaw/workspace/AGENTS.md
~/.openclaw/.sage-uninstall.js
```

## Migration

- **当前 v2.1.11 release 不受影响**：自动化只对未来 release 生效，v2.1.11 仍需手动 publish 一次（已经 publish 过的话就跳过）
- 从 v2.1.12 起：本地 bump version + commit + tag → 推 → `gh release create` → workflow 自动 publish

## Diff

```
 .github/workflows/ci.yml      | 42 +++++++++++++++++++++++++++++++++++
 .github/workflows/release.yml | 50 +++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 92 insertions(+)
```
