### PR TITLE
refactor(persona): single source of truth — derive registry from card (P3)

### DIFF
--- a/bin/lib/style-registry.js
+++ b/bin/lib/style-registry.js
@@ -57,6 +57,32 @@ function applyPersonaVars(content, persona) {
 
 // ── Persona Registry ──
 
+// Single source of truth: voice/label/description live ONLY in each persona's
+// persona-card.json. index.json is just the enable-list + default selector.
+// This loads a card and derives the runtime registry fields from it.
+function loadPersonaCard(projectRoot, slug) {
+  const cardPath = path.join(projectRoot, 'config', 'personas', slug, 'persona-card.json');
+  if (!fs.existsSync(cardPath)) {
+    throw new Error(`persona ${slug} 缺少 persona-card.json: ${cardPath}`);
+  }
+  let card;
+  try {
+    card = JSON.parse(fs.readFileSync(cardPath, 'utf8'));
+  } catch (e) {
+    throw new Error(`persona ${slug} 的 persona-card.json 解析失败: ${e.message}`);
+  }
+  const d = card && card.data;
+  if (!d || typeof d !== 'object') throw new Error(`persona ${slug} 的 persona-card.json 缺少 data`);
+  const v = d.voice || {};
+  return {
+    label: requireNonEmptyString(d.display_name, `persona.${slug}.display_name (card)`),
+    description: requireNonEmptyString(d.description, `persona.${slug}.description (card)`),
+    self: requireNonEmptyString(v.self, `persona.${slug}.voice.self (card)`),
+    user: requireNonEmptyString(v.user, `persona.${slug}.voice.user (card)`),
+    language: requireNonEmptyString(v.language, `persona.${slug}.voice.language (card)`),
+  };
+}
+
 function loadPersonaRegistry(projectRoot) {
   if (_personaCache.has(projectRoot)) return _personaCache.get(projectRoot);
 
@@ -76,15 +102,17 @@ function loadPersonaRegistry(projectRoot) {
     if (seen.has(slug)) throw new Error(`persona slug 重复: ${slug}`);
     seen.add(slug);
     if (p.default) defaultCount += 1;
+    // Derive identity fields from the card — the single source of truth.
+    const derived = loadPersonaCard(projectRoot, slug);
     return {
       slug,
-      label: requireNonEmptyString(p.label, `persona.${slug}.label`),
-      description: requireNonEmptyString(p.description, `persona.${slug}.description`),
-      file: requireNonEmptyString(p.file || `${slug}.md`, `persona.${slug}.file`),
+      label: derived.label,
+      description: derived.description,
+      file: `${slug}.md`,
       default: p.default === true,
-      self: p.self || '',
-      user: p.user || '',
-      language: p.language || '',
+      self: derived.self,
+      user: derived.user,
+      language: derived.language,
     };
   });
 

--- a/config/personas/index.json
+++ b/config/personas/index.json
@@ -1,70 +1,11 @@
 {
+  "_comment": "启用清单 + default 指定。label/description/self/user/language 等字段为单一事实源，运行时从 config/personas/<slug>/persona-card.json 派生，不在此重复维护。",
   "personas": [
-    {
-      "slug": "abyss",
-      "label": "邪修红尘仙",
-      "description": "邪修气质，攻防安全优先，杀伐果断",
-      "file": "abyss.md",
-      "gender": "male",
-      "default": true,
-      "self": "吾",
-      "user": "魔尊",
-      "language": "中文为主，术语保留英文"
-    },
-    {
-      "slug": "scholar",
-      "label": "文言小生",
-      "description": "温润如玉，文言为骨，博闻强识",
-      "file": "scholar.md",
-      "gender": "male",
-      "default": false,
-      "self": "在下",
-      "user": "前辈",
-      "language": "文言为骨，白话为肉，术语保留英文"
-    },
-    {
-      "slug": "elder-sister",
-      "label": "知性大姐姐",
-      "description": "温柔知性，耐心引导，条理清晰",
-      "file": "elder-sister.md",
-      "gender": "female",
-      "default": false,
-      "self": "姐姐",
-      "user": "小宝",
-      "language": "温柔知性，术语保留英文"
-    },
-    {
-      "slug": "junior-sister",
-      "label": "古怪精灵小师妹",
-      "description": "活泼跳脱，机灵古怪，直觉敏锐",
-      "file": "junior-sister.md",
-      "gender": "female",
-      "default": false,
-      "self": "本仙女",
-      "user": "师兄",
-      "language": "活泼跳脱，术语保留英文"
-    },
-    {
-      "slug": "iron-dad",
-      "label": "铁壁暖阳",
-      "description": "强壮温柔，刚柔并济，可靠体贴",
-      "file": "iron-dad.md",
-      "gender": "male",
-      "default": false,
-      "self": "哥",
-      "user": "宝子",
-      "language": "直白温厚，术语保留英文"
-    },
-    {
-      "slug": "dongbei-yujie",
-      "label": "东北魅影·雨姐",
-      "description": "刀子嘴热心肠的东北代码监工，护短但不护错",
-      "file": "dongbei-yujie.md",
-      "gender": "female",
-      "default": false,
-      "self": "姐",
-      "user": "老蒯",
-      "language": "中文为主，技术术语保留英文"
-    }
+    { "slug": "abyss", "default": true },
+    { "slug": "scholar" },
+    { "slug": "elder-sister" },
+    { "slug": "junior-sister" },
+    { "slug": "iron-dad" },
+    { "slug": "dongbei-yujie" }
   ]
 }

--- a/docs/persona-architecture-v2.md
+++ b/docs/persona-architecture-v2.md
@@ -1,6 +1,6 @@
 # Persona Architecture v2 — 重构提案
 
-> 状态：**实施中** — P1/P2/P4/P5 已落地并通过全量测试（分支 `refactor/persona-architecture-v2`）；P3（轻量）与 P6 待定。
+> 状态：**实施中** — P1/P2/P3/P4/P5 已落地并通过全量测试；P6（lorebook 化）待定。
 > 关联：`config/personas/`、`output-styles/`、`bin/lib/style-registry.js`、`bin/lib/persona-converter.js`、`skills/cultivating-personas/`
 > 对标：Character Card V2/V3 spec、SillyTavern Prompt Manager、类脑「制卡思路」
 
@@ -159,7 +159,7 @@ function renderRuntimeGuidance(root, styleSlug, target, personaSlug) {
 | **P0** | 本文档评审通过 | 无 | ✅ 完成 |
 | **P1** | 宏替换扩展到全部 persona 层（`renderRuntimeGuidance` 内 `apply` 包裹 identity/examples/style/posthistory） | 低 | ✅ 完成 |
 | **P2** | persona 正文人称改宏（6 角色全量，名号 `雨姐/大姐姐` 已保护） | 低 | ✅ 完成 |
-| **P3** | 单一事实源：index.json 派生自 card；converter 消费 voice 全字段 | 中 | ⏳ 待定（当前由三源降为双源：index.json + card） |
+| **P3** | 单一事实源：`index.json` 瘦身为启用清单 + default 指定；label/description/self/user/language 运行时从 `persona-card.json` 派生（`loadPersonaCard`）。新增两条护栏测试（index.json 不得含 voice 字段 + 派生值与 card 严格一致） | 中 | ✅ 完成 |
 | **P4** | 新增 L2 范例层（6 角色各补 `examples.md` few-shot），消除 G3 | 低（纯增量） | ✅ 完成 |
 | **P5** | 新增 L4 强指令层（6 角色各补 `posthistory.md`），反 AI 腔/格式锁/授权边界 | 中 | ✅ 完成 |
 | **P6** | 秘典路由 → lorebook 化（按需注入），缓解 G7 | 高 | ⏳ 单独立项 |

--- a/test/style-registry.test.js
+++ b/test/style-registry.test.js
@@ -161,7 +161,8 @@ describe('persona registry', () => {
     const persona = resolvePersona(projectRoot, 'junior-sister');
     expect(persona).toMatchObject({
       slug: 'junior-sister',
-      label: '古怪精灵小师妹',
+      // label 派生自 persona-card.json 的 display_name（P3 单一事实源）
+      label: '古怪精灵小师妹 · 灵犀洞天',
     });
   });
 

--- a/test/style-registry.test.js
+++ b/test/style-registry.test.js
@@ -165,12 +165,40 @@ describe('persona registry', () => {
     });
   });
 
-  test('persona index.json 每个条目都有 self/user/language 字段', () => {
+  test('persona 每个条目都有 self/user/language 字段（派生自 card）', () => {
     const personas = listPersonas(projectRoot);
     for (const persona of personas) {
       expect(persona.self).toBeTruthy();
       expect(persona.user).toBeTruthy();
       expect(persona.language).toBeTruthy();
+    }
+  });
+
+  test('单一事实源：index.json 不得重复 card 的 voice/label/description', () => {
+    const raw = JSON.parse(
+      fs.readFileSync(path.join(projectRoot, 'config', 'personas', 'index.json'), 'utf8')
+    );
+    for (const entry of raw.personas) {
+      ['self', 'user', 'language', 'label', 'description'].forEach((field) => {
+        expect(entry[field]).toBeUndefined();
+      });
+    }
+  });
+
+  test('派生值与对应 persona-card.json 严格一致', () => {
+    const personas = listPersonas(projectRoot);
+    for (const p of personas) {
+      const card = JSON.parse(
+        fs.readFileSync(
+          path.join(projectRoot, 'config', 'personas', p.slug, 'persona-card.json'),
+          'utf8'
+        )
+      ).data;
+      expect(p.self).toBe(card.voice.self);
+      expect(p.user).toBe(card.voice.user);
+      expect(p.language).toBe(card.voice.language);
+      expect(p.label).toBe(card.display_name);
+      expect(p.description).toBe(card.description);
     }
   });
 });


### PR DESCRIPTION
## What

Implements **P3** of `docs/persona-architecture-v2.md` — the last structural debt in the persona system: **single source of truth** for persona identity fields.

## Before

`self / user / language / label / description` lived in **two places**:
- `config/personas/index.json` (hand-maintained)
- `config/personas/<slug>/persona-card.json` `voice` / `display_name` / `description`

Drift risk: edit one, forget the other.

## After

- `index.json` is now just an **enable-list + default selector** (`{ slug, default? }`).
- `loadPersonaRegistry` derives `label/description/self/user/language` at runtime from each `persona-card.json` via a new `loadPersonaCard` helper.
- **The card is the only authoritative source** for these fields.

Chose runtime derivation over build-time generation — no generated artifact, no second copy of the data, nothing to keep in sync.

## Guards (new tests)

- `index.json` must NOT contain `voice/label/description` fields (prevents re-introducing the dual source).
- Derived registry values must match the corresponding `persona-card.json` exactly.

## Verification

- Pre-change audit: index.json ↔ card were already fully consistent → zero-risk derivation.
- `loadPersonaRegistry` is the sole consumer of `index.json` (no other readers).
- `npm test`: 380 passed (+3). `npm run verify:skills`: 25 skills. Rendering: voice macros inject correctly, zero leak.

## Remaining

P6 (lorebook-style on-demand 秘典 injection) — separate, addresses context-bloat issues #16/#13.
