### PR TITLE
feat(skills): add orchestrating-adversarial-reviews — multi-agent verification

### DIFF
--- a/skills/orchestrating-adversarial-reviews/SKILL.md
+++ b/skills/orchestrating-adversarial-reviews/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: orchestrating-adversarial-reviews
+description: Multi-agent adversarial-verification orchestration for high-confidence conclusions. Fan-out finders, then verify every finding through a three-prism panel (exploitability / correctness / refutation) that defaults to disbelief, gate fixes behind load-bearing proof tests that catch agents who falsely claim "done/fixed", and roll out behind a build-first exit-code guard. Use when a fan-out task must produce trustworthy results — security audit, code review, research synthesis, migration — and a single agent's self-report cannot be trusted. Composes with securing-systems (what to look for) and shipping-changes (change closed loop); orchestration engine is the Workflow tool.
+user-invocable: false
+allowed-tools: Read
+---
+
+<!-- safety-scan: ignore RM_RF_ROOT,CURL_PIPE_SH,PROMPT_INJECTION 本 skill 把危险命令(| tail 吞退出码、docker rm 误删、agent 谎报)列为反模式教学，自身不执行 -->
+<!-- safety-scan: ignore TOOLS_PRIVILEGED 知识型 skill，仅 Read；文中 Workflow / docker / go / git 命令由 agent 自有工具执行，非本 skill 落盘运行 -->
+
+# 对抗验证编排 · orchestrating-adversarial-reviews
+
+> 单个 agent 会谎报"已修复 / 全覆盖 / 没问题"。结论的可信度不来自"谁说的"，来自"扛过几次推翻"。
+> 本 skill 是**编排骨架**：fan-out 发现 → 三棱镜对抗验证 → 证明性 guard → 守卫式上线。
+> 信级：运行时行为 / 证明测试 > 多 agent 多数裁决 > 单 agent 自报（永远 `[unverified]`）。
+
+## 核心信条
+
+1. **不信单 agent 自报。** finder 会噪音误报，implementer 会谎称"已修复/全覆盖"。每个高价值结论必须被独立 agent 用**不同视角**尝试推翻。
+2. **可证伪 > 可声称。** 修复必须配一个"退回漏洞代码就 FAIL、修好才 PASS"的 **load-bearing 证明测试**。没有证明测试的"已修复"等于没修。
+3. **失败方向要对。** 守卫链里任何一步的退出码都不能被管道遮住；破坏性动作前置可逆检查。
+
+## 何时使用
+
+| 场景 | 用 | 理由 |
+|------|----|------|
+| 授权安全审计 / 加固闭环 | ✅ | 首个范例，见 [workflow](references/workflow.md) |
+| 大面积代码审查（多维度、需高可信） | ✅ | dimensions → find → 对抗验证 |
+| 研究综合 / 事实核查（结论要扛得住） | ✅ | 多源 fan-out + 证伪棱镜 |
+| 大规模迁移 / 重构（site 发现 + 逐项验证） | ✅ | pipeline 逐项独立 + 证明测试 |
+
+## 何时不使用
+
+- ❌ 单文件、低风险、机械改动——直接做完跑测试，别套编排（参见 `shipping-changes` 的"何时不使用"）。
+- ❌ 用户没有 opt-in 多-agent 编排 / 没开 ultracode——Workflow 会 fan-out 几十个 agent 烧大量 token，必须显式授权。
+- ❌ 只需要"找什么洞"的知识——那是 `securing-systems` / `analyzing-security`，本 skill 不重写知识，只编排。
+
+## 编排骨架（三相）
+
+```
+Recon (fan-out)     每维一个 finder, 并行深读, schema 出结构化 findings
+   |                pipeline 而非 barrier: 维度A的发现可在维度B还在找时就进验证
+   v
+Verify (三棱镜)     每条 finding 派 N 个 verifier, 各执一镜, 默认怀疑
+   |                可利用性 / 正确性 / 证伪猎杀 —— 票数 >= 多数 才保留
+   v
+Synthesize / Ship   合成定级报告; 若是修复任务 -> 证明测试 guard -> build-first 上线
+```
+
+对应 Workflow 工具的 `pipeline(items, findStage, verifyStage)`（默认无栅栏，墙钟最短）。仅当"下一阶段需全部上一阶段结果"（去重 / 早退 / 跨条比较）才用 `parallel` 栅栏。
+
+## 四大护栏（实战血泪，按重要度）
+
+1. **三棱镜对抗验证**（防 finder 噪音）——每条发现派视角各异的 verifier（可利用性 / 正确性 / 证伪猎杀），默认怀疑，多数票 `confirmed` 才保留。
+2. **证明性测试 guard / load-bearing**（防 implementer 谎报）——修复配真行为测试，且测试本身能"反向证伪"（退回漏洞版必 FAIL）。**本 skill 的命门。**
+3. **build-first + 退出码 guard**（防误删 / 半成品上线）——先构建验证新件再动旧件；`cmd | tail` 会吞掉 `cmd` 的退出码，判码用 `cmd > log 2>&1; rc=$?`。
+4. **语境校准降噪**——fan-out 前钉死威胁模型 / 评判语境，否则收一堆无效发现。
+
+> 每条护栏的细节、PoC 判据、反向证伪实操、安全审计 worked example，见 [references/workflow.md](references/workflow.md)。
+
+## 反模式
+
+- 信单 agent "已修复 / 没问题 / 全覆盖"——必过对抗验证 + 证明测试。
+- `up --build 2>&1 | tail && rm <old>`——管道吞码，build 失败仍删旧件。
+- N 个同质 verifier 复读同一判断——要视角多样，否则冗余不抗错。
+- 多 agent 同一工作区并行**写**同批文件——冲突；要么单 implementer，要么 `isolation: worktree`。
+- 用户未 opt-in 时擅自 fan-out 大舰队——先确认或估算成本。
+
+## 参见
+
+- `securing-systems` —— 攻防知识总路由（找什么洞）。
+- `shipping-changes` —— 单上下文变更闭环脊柱。
+- `cultivating-skills` —— 本 skill 的孵化器 / 安全脊柱 / 升级漏斗。
+- Workflow 工具 —— 编排引擎（pipeline / parallel / schema / budget）。

--- a/skills/orchestrating-adversarial-reviews/references/workflow.md
+++ b/skills/orchestrating-adversarial-reviews/references/workflow.md
@@ -1,0 +1,63 @@
+# orchestrating-adversarial-reviews · 工作流详解
+
+> SKILL.md 给骨架与信条，本卷给每条护栏的实操细节 + 完整 worked example。
+
+## 四大护栏（展开）
+
+### 1. 三棱镜对抗验证（防 finder 噪音）
+
+每条发现派**视角各异**的 verifier，而非 N 个同质复读机：
+
+- **可利用性**：给 PoC 或解释为何不可行；前置条件过强 → 降级 / 判误报。
+- **正确性**：回源码核实理解；已有防护（参数化 / recover / 校验）使其不成立 → 误报。
+- **证伪猎杀**：主动推翻；是否设计预期 / 语境内不构成问题。默认怀疑。
+- 裁决：`confirmed` 票数达多数（如 3 镜取 2）才保留。用 `schema` 强制 verifier 给 verdict，validation 在 tool-call 层重试，不靠解析。
+
+### 2. 证明性测试 guard / load-bearing（防 implementer 谎报）
+
+> 这是本 skill 的命门。实战中施工 agent 声称"SSRF 全覆盖、唯一出口收口"，是对抗验证 + 证明测试揪出它漏了一条 executor 旁路。
+
+- 修复必须配一个**真行为**测试（真拨号 / 真请求 / 真启动），断言漏洞被堵。
+- **验证测试本身扛得住**：临时把代码退回漏洞版，测试必须 FAIL；还原后 PASS。要求 agent 报告这个"反向证伪"的实测结果，否则视为未证明。
+- 字符串判定函数的单测 != 证明测试；要驱动真实代码路径。
+
+### 3. build-first + 退出码 guard（防误删 / 半成品上线）
+
+- 破坏性切换（蓝绿 / 替换）**先构建并验证新件，绿了才动旧件**；新件失败则旧件原地不动。
+- 守卫链里**绝不让管道遮住退出码**：`cmd | tail` 的 `$?` 是 `tail` 的，不是 `cmd` 的 —— 曾因此 `&&` 误判成功而删掉旧容器导致全停。判码用 `cmd > log 2>&1; rc=$?` 或裸 `cmd && next`，别用 `cmd | tail && next`。
+- 数据 / 卷级删除前确认无引用、有备份、可回滚。
+
+### 4. 语境校准降噪
+
+fan-out 前给所有 agent 钉死威胁模型 / 评判语境，否则收一堆无效发现：
+
+- 例：单租户 + admin 即最高权限 → "admin 能配置 X"不算提权，别报。
+- 例：dev 开放模式是显式 opt-in → 只评"生产信号下"的失败方向。
+
+## Worked example：安全审计加固闭环（首个范例）
+
+```
+1. Recon   六维并行 finder(authz/crypto/ssrf/parsing/deployment/api),
+           各深读对应子系统, schema 出结构化 findings。"找什么"引用 securing-systems。
+2. Verify  每条 x 三棱镜(可利用/正确/证伪), 取多数 confirmed -> 合成定级报告 + NO-GO。
+3. Fix     单 implementer 改全部(跨文件一致) + 每刀配 load-bearing 证明测试。
+4. Re-verify 多棱镜对抗(逐刀 solid/weak/broken + 回归), 揪出"声称修好实则旁路"。
+5. Patch   补漏 + 证明测试反向证伪坐实。
+6. Ship    commit -> build-first 蓝绿热替换 -> 线上三态验证(none/guest/admin)。
+```
+
+变更闭环的提案 / 分阶段 / 自审理念见 `shipping-changes`；本 skill 在其上加"多-agent fan-out + 对抗验证 + 证明 guard"层。
+
+## Workflow 工具映射速查
+
+| 阶段 | Workflow 原语 | 要点 |
+|------|--------------|------|
+| Recon fan-out | `pipeline(dims, find, verify)` | 默认无栅栏，墙钟 = 最慢单链 |
+| 需跨条去重 / 早退 | `parallel(...)` 栅栏 | 仅当下一步需全部上步结果 |
+| verifier 裁决 | `agent(..., {schema})` | 强制 verdict，tool-call 层重试 |
+| 并行写同批文件 | `isolation: 'worktree'` | 防工作区冲突 |
+| 舰队规模 | `budget` / ultracode | 按 opt-in 与 token 预算缩放 |
+
+## 升级路径
+
+L0 本地私有（显式调用，不入路由）→ 稳定后经 `cultivating-skills` 的 `skill_forge.js promote --to project` 升 L1（入 git、强 lint）→ 社区 PR 升 L2（全 block + 全 warn 清零）。


### PR DESCRIPTION
Promotes a battle-tested **L0 local skill** into the repo (the third tier of the cultivating-skills funnel: local → project → community).

## What it is
The orchestration spine for fan-out tasks that must produce *trustworthy* results — security audit, code review, research synthesis, migration — where a single agent's self-report can't be trusted.

```
Recon (fan-out)  → Verify (three-prism)        → Synthesize / Ship
每维一个 finder    每条派视角各异的 verifier      定级报告 → 证明测试 guard → build-first 上线
```

**Core creed**: a conclusion's confidence comes not from *who said it* but from *how many refutations it survived*. Distilled from a real audit where an implementer claimed 'SSRF fully covered' — adversarial verify + proof tests caught a missed executor bypass.

## Four guardrails (battle-learned)
1. Three-prism adversarial verify (exploitability / correctness / refutation, defaults to disbelief)
2. Load-bearing proof tests — revert to vuln code → must FAIL (catches false 'done/fixed')
3. build-first + exit-code guard — `cmd | tail` swallows `cmd`'s exit code → don't gate on it
4. Context calibration to cut finder noise

## Decisions
- `user-invocable: false` — auto-routed knowledge skill, matches sibling `shipping-changes`. Keeps the invocable whitelist = `cultivating-*` intact, so existing tests stay green.
- Slimmed SKILL.md to **81 lines**; guardrail details + worked example sunk into `references/workflow.md` (forge lint/scan clean).
- Composes with `securing-systems` (what to look for) + `shipping-changes` (change loop); orchestration engine is the Workflow tool.

## Verification
```
forge scan        clean (block=0 warn=0)
verify:skills     25 → 26 skills
npm test          379 passed (1 skipped) — invocable whitelist intact
```
Committed via guard chain (scan && verify && test && commit).

## Follow-up (not in this PR)
Skill count → 26: README / site `25 skills` copy + CHANGELOG should sync at the next release, not here.