### PR TITLE
chore(release): v4.3.0 — adversarial-review orchestration + skill count 26

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "code-abyss",
-  "version": "4.2.0",
-  "description": "为 Claude Code / Codex CLI / Gemini CLI / OpenClaw 注入可切换人格、主动执行导向、5种输出风格与24个工程技能（含自我进化炼炉）",
+  "version": "4.3.0",
+  "description": "为 Claude Code / Codex CLI / Gemini CLI / OpenClaw 注入可切换人格、主动执行导向、5种输出风格与26个工程技能（含自我进化炼炉）",
   "keywords": [
     "claude",
     "claude-code",

--- a/site/i18n.js
+++ b/site/i18n.js
@@ -1,7 +1,7 @@
 const I18N = {
   en: {
     'site.title': 'Code Abyss — Personality, depth, and a security spine',
-    'site.desc': 'Composable persona + style + 25 engineering skills with 4 native security domains and a self-evolution forge. For Claude Code, Codex, Gemini CLI & OpenClaw.',
+    'site.desc': 'Composable persona + style + 26 engineering skills with 4 native security domains and a self-evolution forge. For Claude Code, Codex, Gemini CLI & OpenClaw.',
     'nav.how': 'How',
     'nav.security': 'Security',
     'nav.evolve': 'Evolve',
@@ -11,7 +11,7 @@ const I18N = {
     'hero.badge': '4.2 — Persona Architecture v2 · Apache-free',
     'hero.title.1': 'Give your AI agent',
     'hero.title.2': 'a personality.',
-    'hero.sub': 'Composable identity, style, and <b>25 engineering skills</b><br>— including <b>4 native security domains</b> and a <b>self-evolution forge</b>.',
+    'hero.sub': 'Composable identity, style, and <b>26 engineering skills</b><br>— including <b>4 native security domains</b> and a <b>self-evolution forge</b>.',
     'hero.browse': 'Browse Personas',
     'hero.submit': 'Submit Yours',
     'hero.runs': 'Runs on',
@@ -138,7 +138,7 @@ const I18N = {
   },
   zh: {
     'site.title': 'Code Abyss — 人格、深度，与一根安全脊柱',
-    'site.desc': '可组合的人格 + 风格 + 25 项工程技能，含 4 个原生安全领域与自我进化炼炉。支持 Claude Code, Codex, Gemini CLI 和 OpenClaw。',
+    'site.desc': '可组合的人格 + 风格 + 26 项工程技能，含 4 个原生安全领域与自我进化炼炉。支持 Claude Code, Codex, Gemini CLI 和 OpenClaw。',
     'nav.how': '原理',
     'nav.security': '安全',
     'nav.evolve': '进化',
@@ -148,7 +148,7 @@ const I18N = {
     'hero.badge': '4.2 — 人格架构 v2 · 无 Apache 依赖',
     'hero.title.1': '给你的 AI 助手',
     'hero.title.2': '一个人格。',
-    'hero.sub': '可组合的身份、风格，与 <b>25 项工程技能</b><br>—— 内含 <b>4 个原生安全领域</b> 与 <b>自我进化炼炉</b>。',
+    'hero.sub': '可组合的身份、风格，与 <b>26 项工程技能</b><br>—— 内含 <b>4 个原生安全领域</b> 与 <b>自我进化炼炉</b>。',
     'hero.browse': '浏览人格',
     'hero.submit': '提交你的',
     'hero.runs': '运行于',

--- a/site/index.html
+++ b/site/index.html
@@ -72,7 +72,7 @@
             <span data-i18n="hero.title.1">Give your AI agent</span><br>
             <span class="accent" data-i18n="hero.title.2">a personality.</span>
           </h1>
-          <p class="lead" data-i18n="hero.sub" data-i18n-html>Composable identity, style, and <b>25 engineering skills</b><br>— including <b>4 native security domains</b> and a <b>self-evolution forge</b>.</p>
+          <p class="lead" data-i18n="hero.sub" data-i18n-html>Composable identity, style, and <b>26 engineering skills</b><br>— including <b>4 native security domains</b> and a <b>self-evolution forge</b>.</p>
           <div class="hero-install">
             <span class="prompt-sign">$</span>
             <code>npx code-abyss -t claude -y</code>


### PR DESCRIPTION
Release v4.3.0 (minor — new feature, no breaking).

## Included
- **orchestrating-adversarial-reviews** skill (merged via #38) ships in this release.
- Skill count **25 → 26** synced across site/i18n.js (en/zh), site/index.html, package.json description.
- CHANGELOG 4.3.0 entry.

After merge: tag v4.3.0 + GitHub Release → release.yml verifies tag==package.json, runs test + verify:skills, npm publish --provenance.

## Verification
```
npm test       379 passed (1 skipped)
verify:skills  26 skills
residual 25/24 copy  CLEAN
```