### PR TITLE
docs: backfill v4.3.0 changelog + sync skill count to 26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [4.3.0] - 2026-05-31
+
+> **Adversarial-review orchestration release.** 新增多 agent 对抗验证编排 skill，并把站点/包描述的技能数同步到 26。
+
+### Added
+
+- **orchestrating-adversarial-reviews** — 多 agent 对抗验证编排 skill（从 L0 本地经 cultivating-skills 漏斗升入仓库）。fan-out 发现 → 三棱镜对抗验证（可利用性 / 正确性 / 证伪猎杀，默认怀疑）→ load-bearing 证明测试 guard（揪出谎报"已修复/全覆盖"的 agent）→ build-first 退出码守卫上线。核心信条：结论可信度不来自"谁说的"，来自"扛过几次推翻"。与 `securing-systems`（找什么洞）+ `shipping-changes`（变更闭环）职责切分；编排引擎为 Workflow 工具。`user-invocable: false`，知识型自动路由。
+
+### Changed
+
+- skill 总数由 25 升至 26（orchestrating-adversarial-reviews）。
+- 站点 `site/index.html` + `site/i18n.js`（中英）与 `package.json` description 的技能数同步到 26。
+
 ## [4.2.0] - 2026-05-30
 
 > **Persona architecture v2 + skill sediment release.** 人格系统按「注入位置/作用」重构为五层（对标 Character Card / SillyTavern），宏全局化让任意 persona×style 组合不再人格分裂；persona 身份字段收敛为单一事实源；新增两枚 skill（变更闭环编排 + release pipeline 实战秘典）。

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   </a>
 </p>
 
-<h3 align="center">Composable persona · style · 24 engineering skills · 4 native security domains · self-evolution forge<br/>for Claude Code · Codex CLI · Gemini CLI · OpenClaw</h3>
+<h3 align="center">Composable persona · style · 26 engineering skills · 4 native security domains · self-evolution forge<br/>for Claude Code · Codex CLI · Gemini CLI · OpenClaw</h3>
 
 <p align="center">
   <a href="https://www.npmjs.com/package/code-abyss"><img src="https://img.shields.io/npm/v/code-abyss?color=9b8cff&label=npm&style=flat-square" alt="npm"></a>
@@ -52,7 +52,7 @@ Pick any persona. Pair it with any style. The behavior layer (iron laws, executi
 ### What's new in v4
 
 - **4 native security domains** — 4073 lines of original defense engineering (no Apache-2.0 upstream)
-- **24 skills total**, all `SKILL.md` ≤ 90 lines (avg 58), heavy content lives in `references/`
+- **26 skills total**, all `SKILL.md` ≤ 90 lines (avg 58), heavy content lives in `references/`
 - 5 verify skills rewritten as **judgment-type knowledge** (when to use, how to interpret output, exemption rules)
 - Office skills slim to under 100 lines each; 4 design systems consolidated into one selector skill
 - **v4.1 — self-evolution forge**: `cultivating-skills` / `cultivating-personas` let the agent distill repeated workflows into reusable skills, with a safety scan and a three-tier publish funnel (local → project → community)

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -6,7 +6,7 @@
   </a>
 </p>
 
-<h3 align="center">可组合的人格 · 风格 · 24 项工程技能 · 4 个原生安全领域 · 自我进化炼炉<br/>支持 Claude Code · Codex CLI · Gemini CLI · OpenClaw</h3>
+<h3 align="center">可组合的人格 · 风格 · 26 项工程技能 · 4 个原生安全领域 · 自我进化炼炉<br/>支持 Claude Code · Codex CLI · Gemini CLI · OpenClaw</h3>
 
 <p align="center">
   <a href="https://www.npmjs.com/package/code-abyss"><img src="https://img.shields.io/npm/v/code-abyss?color=9b8cff&label=npm&style=flat-square" alt="npm"></a>
@@ -52,7 +52,7 @@
 ### v4 新内容
 
 - **4 个原生安全领域** —— 4073 行原创防御工程内容（无 Apache-2.0 上游依赖）
-- **24 个 skill**，所有 `SKILL.md` ≤ 90 行（平均 58 行），重内容下沉 `references/`
+- **26 个 skill**，所有 `SKILL.md` ≤ 90 行（平均 58 行），重内容下沉 `references/`
 - 5 个 verify skill 重写为**判断型知识**（何时用、如何解读输出、豁免规则）
 - Office skill 全部砍至 100 行内；4 套设计系统合并为单一选型 skill
 - **v4.1 自我进化炼炉**：`cultivating-skills` / `cultivating-personas` 让 Agent 能识别会话中"该沉淀了"的信号，把重复方法论 / 稳定声音沉淀为可复用 skill / persona，自带安全扫描 + 三级漏斗（本地 → 项目 → 社区）
@@ -184,7 +184,7 @@ npx code-abyss -t claude --persona elder-sister --style abyss-cultivator -y
 
 ## 技能矩阵
 
-24 个领域技能，扁平目录结构，对齐 [agentskills.io](https://agentskills.io/specification) 规范（含 Code Abyss 扩展）。技能按上下文自动加载——Agent 在正确的时机读取正确的知识，无需手动指定。`SKILL.md` 平均 58 行，全部 ≤ 90 行，重内容下沉 `references/`。
+26 个领域技能，扁平目录结构，对齐 [agentskills.io](https://agentskills.io/specification) 规范（含 Code Abyss 扩展）。技能按上下文自动加载——Agent 在正确的时机读取正确的知识，无需手动指定。`SKILL.md` 平均 58 行，全部 ≤ 90 行，重内容下沉 `references/`。
 
 | 领域 | 覆盖范围 |
 |---|---|
@@ -282,7 +282,7 @@ const gpt = toGPTInstructions(card, { identityContent });// → OpenAI 自定义
 |---|---|---|
 | **身份** | 扁平客服腔 | 有名字、有声音、稳定一致 |
 | **执行** | 临场发挥，因 prompt 而异 | 铁律 + 执行链固化 |
-| **领域深度** | 通用最佳实践 | 24 个技能按上下文加载（平均 58 行） |
+| **领域深度** | 通用最佳实践 | 26 个技能按上下文加载（平均 58 行） |
 | **安全深度** | OWASP 复读机 | 4 个原生套件 · 4073 行 · 检测信号 + 缓解模式 |
 | **跨平台** | 每个 CLI 重写一遍 prompt | 一份规范，四个平台 |
 | **可复现** | 跨会话 prompt 漂移 | `persona-card.json` 版本化 |
@@ -296,7 +296,7 @@ const gpt = toGPTInstructions(card, { identityContent });// → OpenAI 自定义
 git clone https://github.com/telagod/code-abyss && cd code-abyss
 npm install
 npm test                    # 375 个测试
-npm run verify:skills       # 验证 24 个技能契约
+npm run verify:skills       # 验证 26 个技能契约
 ```
 
 **添加技能**——创建 `skills/<动名词>/SKILL.md`，按 [SKILL frontmatter 规范](https://agentskills.io/specification) 编写，可选添加 `scripts/` 放可执行工具。`npm run verify:skills` 验证契约。


### PR DESCRIPTION
Docs-only follow-up to the v4.3.0 release (no version bump, npm untouched).

## Why
v4.3.0 shipped without a CHANGELOG entry, and README still said `24 skills` while the site already said 26 — a live self-contradiction.

## Fix
- **CHANGELOG**: add the missing `[4.3.0]` section (orchestrating-adversarial-reviews + skill-count sync).
- **README.md** + **docs/README.zh-CN.md**: `24` → `26 engineering skills` (header, totals line, domain-depth table, verify command).

## Verification
```
residual 24/25 skill-count copy   CLEAN (only legit '1246 行' remains)
verify:skills                     26 skills
```
Committed via guard chain (verify && commit). Closes the doc drift recorded after #38.