### PR TITLE
chore(release): v4.4.0 — hardware + academic writing + injection defense

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [4.4.0] - 2026-06-08
+
+> **Hardware + academic writing + injection defense release.** 三个实战 skill 从 L0 本地升入项目（26→29），新增 prompt injection 防御与执行驱动力共享行为模块。
+
+### Added
+
+- **designing-hardware-products** — 全栈硬件产品管线：需求 → ESP-IDF 固件(FreeRTOS) → KiCad PCB → UniApp 跨平台 App → release zip。5 份 reference 覆盖高压电路设计、ESP-IDF 模式、UniApp 模式、管线阶段、KiCad 9 quirks。`user-invocable: true`。
+- **operating-kicad-eda** — KiCad 9 MCP 工具路由器，覆盖 17 个 MCP tool。四条铁律：不手布线(autoroute-only)、不猜名(library-first)、串行写 PCB、改后必验(DRC gate)。3 份 reference。`user-invocable: true`。
+- **reducing-aigc-detection** — 系统化降低论文 AIGC 检测率，支持维普/知网/Turnitin 三平台。三层改写策略（结构→词汇→内容注入），docx Run 级编辑保留脚注，AI 特征词黑名单(中/英)，平台特性档案。2 份 reference。`user-invocable: true`。
+- **injection-awareness.md** — 共享行为模块：Prompt Injection 三层防御（检测模式 → 运行时白名单 → 响应协议），per-target 白名单覆盖 Claude/Codex/Gemini/OpenClaw。
+- **execution-drive.md** — 共享行为模块：行动优先 + 完成承诺 + 反模式识别(反懒惰五条) + 终结门自检 + 安全阀。
+- **llm-security.md 追加** — Injection-Resilient Persona Design 参考：架构模板、设计原则、对抗评估、多 Agent 场景。
+
+### Changed
+
+- skill 总数由 26 升至 29（+3 domain skills）。
+- invocable skill 由 2 升至 5（cultivating 系列 + 3 新 skill）。
+- README / CLAUDE.md / package.json / site (i18n.js + index.html) 技能数同步到 29。
+- README skill 表格新增 Hardware/Embedded 与 Academic Writing 两个领域行。
+- `SHARED_FILES_ORDER` 新增 injection-awareness + execution-drive 渲染顺序。
+
+### CI
+
+- Skill contract gate: `npm run verify:skills` — 29 skills 通过
+- Test suite: 379 tests pass, Node 18/20/22
+- Smoke install: Claude / Codex / Gemini / OpenClaw × ubuntu / macos / windows 全绿
+
 ## [4.3.0] - 2026-05-31
 
 > **Adversarial-review orchestration release.** 新增多 agent 对抗验证编排 skill，并把站点/包描述的技能数同步到 26。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-abyss",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "description": "为 Claude Code / Codex CLI / Gemini CLI / OpenClaw 注入可切换人格、主动执行导向、5种输出风格与29个工程技能（含自我进化炼炉）",
   "keywords": [
     "claude",


### PR DESCRIPTION
## Summary

**v4.4.0** — three battle-tested local skills promoted to project level (26→29), plus two shared behavior modules for injection defense and execution discipline.

### New skills (L0 → L1)
- **designing-hardware-products** — full-stack hardware pipeline (ESP-IDF + KiCad + UniApp), 5 references
- **operating-kicad-eda** — KiCad 9 MCP tool router (17 tools), 3 references
- **reducing-aigc-detection** — AIGC detection reduction for 维普/知网/Turnitin, 2 references

### New shared behavior
- **injection-awareness** — three-layer prompt injection defense with per-target runtime whitelists
- **execution-drive** — action-first rules, anti-laziness patterns, output self-check gate

### Docs
- Skill count synced 26→29 across README/CLAUDE.md/package.json/site
- CHANGELOG backfilled for all changes since v4.3.0

## Test plan
- [x] `npm run verify:skills` — 29 skills pass
- [x] `npm test` — 379 tests pass
- [ ] CI green on Node 18/20/22 + smoke install across 4 targets × 3 OS