### PR TITLE
feat(persona): dynamic persona loading — core-only npm, remote fetch on demand

### DIFF
--- a/bin/lib/persona-fetch.js
+++ b/bin/lib/persona-fetch.js
@@ -1,0 +1,82 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const https = require('https');
+const http = require('http');
+const os = require('os');
+
+const CACHE_BASE = path.join(os.homedir(), '.code-abyss', 'personas');
+
+function getCacheDir(slug) {
+  return path.join(CACHE_BASE, slug);
+}
+
+function isPersonaCached(slug) {
+  const dir = getCacheDir(slug);
+  return fs.existsSync(path.join(dir, 'persona-card.json'))
+    && fs.existsSync(path.join(dir, `${slug}.md`));
+}
+
+function fetch(url) {
+  return new Promise((resolve, reject) => {
+    const mod = url.startsWith('https') ? https : http;
+    mod.get(url, { headers: { 'User-Agent': 'code-abyss' } }, (res) => {
+      if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+        return fetch(res.headers.location).then(resolve, reject);
+      }
+      if (res.statusCode !== 200) {
+        res.resume();
+        return resolve(null);
+      }
+      const chunks = [];
+      res.on('data', (c) => chunks.push(c));
+      res.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+      res.on('error', reject);
+    }).on('error', reject);
+  });
+}
+
+async function fetchPersona(slug, remoteBase) {
+  const cacheDir = getCacheDir(slug);
+  fs.mkdirSync(cacheDir, { recursive: true });
+
+  const base = remoteBase.replace(/\/+$/, '');
+
+  const cardUrl = `${base}/${slug}/persona-card.json`;
+  const cardContent = await fetch(cardUrl);
+  if (!cardContent) {
+    throw new Error(`远程人格 ${slug} 不存在: ${cardUrl} 返回非 200`);
+  }
+  fs.writeFileSync(path.join(cacheDir, 'persona-card.json'), cardContent);
+
+  const identityUrl = `${base}/${slug}.md`;
+  const identityContent = await fetch(identityUrl);
+  if (!identityContent) {
+    throw new Error(`远程人格 ${slug} 缺少 identity 文件: ${identityUrl}`);
+  }
+  fs.writeFileSync(path.join(cacheDir, `${slug}.md`), identityContent);
+
+  for (const optional of ['examples.md', 'posthistory.md']) {
+    const url = `${base}/${slug}/${optional}`;
+    const content = await fetch(url);
+    if (content) {
+      fs.writeFileSync(path.join(cacheDir, optional), content);
+    }
+  }
+
+  return cacheDir;
+}
+
+async function ensurePersona(slug, remoteBase) {
+  if (isPersonaCached(slug)) return getCacheDir(slug);
+  return fetchPersona(slug, remoteBase);
+}
+
+module.exports = {
+  getCacheDir,
+  isPersonaCached,
+  fetchPersona,
+  ensurePersona,
+  CACHE_BASE,
+};

--- a/bin/lib/select.js
+++ b/bin/lib/select.js
@@ -97,12 +97,23 @@ function createSelectFlows(deps) {
     };
   }
 
+  async function ensureRemotePersona(persona) {
+    if (persona.core !== false) return persona;
+    const { getRemoteBase } = require('./style-registry');
+    const { ensurePersona } = require('./persona-fetch');
+    const remoteBase = getRemoteBase(PKG_ROOT);
+    if (!remoteBase) throw new Error(`远程人格 ${persona.slug} 需要 remote.base 配置`);
+    info(`${c.d('拉取远程人格')} ${c.mag(persona.slug)} ...`);
+    await ensurePersona(persona.slug, remoteBase);
+    return persona;
+  }
+
   async function resolveInstallPersona() {
     const requested = getRequestedPersonaSlug();
     if (requested) {
       const persona = resolvePersona(PKG_ROOT, requested);
       if (!persona) throw new Error(`未知人格预设: ${requested}`);
-      return persona;
+      return ensureRemotePersona(persona);
     }
     if (getAutoYes()) return getDefaultPersona(PKG_ROOT);
 
@@ -118,7 +129,8 @@ function createSelectFlows(deps) {
       })),
       default: defaultPersona.slug,
     });
-    return resolvePersona(PKG_ROOT, slug);
+    const persona = resolvePersona(PKG_ROOT, slug);
+    return ensureRemotePersona(persona);
   }
 
   async function resolveInstallStyle(targetName) {

--- a/bin/lib/style-registry.js
+++ b/bin/lib/style-registry.js
@@ -59,9 +59,8 @@ function applyPersonaVars(content, persona) {
 
 // ── Persona Registry ──
 
-// Single source of truth: voice/label/description live ONLY in each persona's
-// persona-card.json. index.json is just the enable-list + default selector.
-// This loads a card and derives the runtime registry fields from it.
+// Core personas derive metadata from persona-card.json (single source of truth).
+// Remote personas carry snapshot metadata in index.json for offline selection.
 function loadPersonaCard(projectRoot, slug) {
   const cardPath = path.join(projectRoot, 'config', 'personas', slug, 'persona-card.json');
   if (!fs.existsSync(cardPath)) {
@@ -95,6 +94,7 @@ function loadPersonaRegistry(projectRoot) {
   if (!personas || personas.length === 0) {
     throw new Error('config/personas/index.json 缺少 personas 列表');
   }
+  const remoteBase = parsed.remote && parsed.remote.base;
 
   const seen = new Set();
   let defaultCount = 0;
@@ -104,17 +104,35 @@ function loadPersonaRegistry(projectRoot) {
     if (seen.has(slug)) throw new Error(`persona slug 重复: ${slug}`);
     seen.add(slug);
     if (p.default) defaultCount += 1;
-    // Derive identity fields from the card — the single source of truth.
-    const derived = loadPersonaCard(projectRoot, slug);
+
+    const isCore = p.core !== false;
+
+    if (isCore) {
+      const derived = loadPersonaCard(projectRoot, slug);
+      return {
+        slug,
+        label: derived.label,
+        description: derived.description,
+        file: `${slug}.md`,
+        default: p.default === true,
+        core: true,
+        self: derived.self,
+        user: derived.user,
+        language: derived.language,
+      };
+    }
+
+    // Remote persona — use snapshot metadata from index.json.
     return {
       slug,
-      label: derived.label,
-      description: derived.description,
+      label: requireNonEmptyString(p.label, `persona.${slug}.label`),
+      description: requireNonEmptyString(p.description, `persona.${slug}.description`),
       file: `${slug}.md`,
       default: p.default === true,
-      self: derived.self,
-      user: derived.user,
-      language: derived.language,
+      core: false,
+      self: requireNonEmptyString(p.self, `persona.${slug}.self`),
+      user: requireNonEmptyString(p.user, `persona.${slug}.user`),
+      language: requireNonEmptyString(p.language, `persona.${slug}.language`),
     };
   });
 
@@ -122,37 +140,62 @@ function loadPersonaRegistry(projectRoot) {
     throw new Error('persona registry 必须且只能有一个 default persona');
   }
 
-  _personaCache.set(projectRoot, normalized);
-  return normalized;
+  const result = { personas: normalized, remoteBase: remoteBase || null };
+  _personaCache.set(projectRoot, result);
+  return result;
 }
 
 function listPersonas(projectRoot) {
-  return loadPersonaRegistry(projectRoot);
+  return loadPersonaRegistry(projectRoot).personas;
 }
 
 function getDefaultPersona(projectRoot) {
-  const personas = loadPersonaRegistry(projectRoot);
+  const { personas } = loadPersonaRegistry(projectRoot);
   return personas.find(p => p.default);
 }
 
 function resolvePersona(projectRoot, slug) {
-  const personas = loadPersonaRegistry(projectRoot);
+  const { personas } = loadPersonaRegistry(projectRoot);
   return personas.find(p => p.slug === slug) || null;
 }
 
-function readPersonaContent(projectRoot, persona) {
-  const personaPath = path.join(projectRoot, 'config', 'personas', persona.file);
-  return fs.readFileSync(personaPath, 'utf8');
+function getRemoteBase(projectRoot) {
+  return loadPersonaRegistry(projectRoot).remoteBase;
 }
 
-// Optional per-persona layer files live alongside persona-card.json in
-// config/personas/<slug>/. Returns '' when the file is absent so the layer
-// is dropped by the assembler — keeping output byte-identical to v1 until
-// the new layers are authored.
+// Resolve the base directory for a persona's files.
+// For non-core personas: check local config/personas/ first (repo dev mode),
+// then fall back to cache dir (npm package mode where files are excluded).
+function resolvePersonaBase(projectRoot, persona) {
+  const localBase = path.join(projectRoot, 'config', 'personas');
+  if (persona.core !== false) return localBase;
+  const localIdentity = path.join(localBase, persona.file);
+  if (fs.existsSync(localIdentity)) return localBase;
+  const { getCacheDir } = require('./persona-fetch');
+  return getCacheDir(persona.slug);
+}
+
+function readPersonaContent(projectRoot, persona) {
+  const base = resolvePersonaBase(projectRoot, persona);
+  return fs.readFileSync(path.join(base, persona.file), 'utf8');
+}
+
+// Optional per-persona layer files. For core personas they live in
+// config/personas/<slug>/. For remote personas, check local dir first, then cache.
 function readPersonaLayer(projectRoot, persona, filename) {
-  const layerPath = path.join(projectRoot, 'config', 'personas', persona.slug, filename);
-  if (!fs.existsSync(layerPath)) return '';
-  return fs.readFileSync(layerPath, 'utf8').replace(/\s+$/, '');
+  const base = resolvePersonaBase(projectRoot, persona);
+  const localLayer = path.join(base, persona.slug, filename);
+  if (fs.existsSync(localLayer)) {
+    return fs.readFileSync(localLayer, 'utf8').replace(/\s+$/, '');
+  }
+  if (persona.core === false) {
+    const { getCacheDir } = require('./persona-fetch');
+    const cacheLayer = path.join(getCacheDir(persona.slug), filename);
+    if (fs.existsSync(cacheLayer)) {
+      return fs.readFileSync(cacheLayer, 'utf8').replace(/\s+$/, '');
+    }
+  }
+  return '';
 }
 
 // ── Style Registry ──
@@ -303,6 +346,7 @@ module.exports = {
   listPersonas,
   getDefaultPersona,
   resolvePersona,
+  getRemoteBase,
   readPersonaContent,
   readPersonaLayer,
   renderCodexAgents,

--- a/config/personas/index.json
+++ b/config/personas/index.json
@@ -1,11 +1,39 @@
 {
-  "_comment": "启用清单 + default 指定。label/description/self/user/language 等字段为单一事实源，运行时从 config/personas/<slug>/persona-card.json 派生，不在此重复维护。",
+  "_comment": "Core personas derive metadata from persona-card.json at load time. Remote personas carry snapshot metadata here for offline selection — full content is fetched on demand from remote.base.",
+  "remote": {
+    "base": "https://raw.githubusercontent.com/telagod/code-abyss/main/config/personas"
+  },
   "personas": [
-    { "slug": "abyss", "default": true },
-    { "slug": "scholar" },
-    { "slug": "elder-sister" },
-    { "slug": "junior-sister" },
-    { "slug": "iron-dad" },
-    { "slug": "dongbei-yujie" }
+    { "slug": "abyss", "default": true, "core": true },
+    {
+      "slug": "scholar", "core": false,
+      "label": "文言小生 · 墨渊书阁",
+      "description": "Literary Chinese scholar persona for meticulous engineering.",
+      "self": "在下", "user": "前辈", "language": "文言为骨，白话为肉，术语保留英文"
+    },
+    {
+      "slug": "elder-sister", "core": false,
+      "label": "知性大姐姐 · 星霜雅筑",
+      "description": "Warm, insightful elder-sister persona for patient technical mentoring.",
+      "self": "姐姐", "user": "小宝", "language": "温柔知性，术语保留英文"
+    },
+    {
+      "slug": "junior-sister", "core": false,
+      "label": "古怪精灵小师妹 · 灵犀洞天",
+      "description": "Hyperactive junior-sister persona with razor-sharp intuition.",
+      "self": "本仙女", "user": "师兄", "language": "活泼跳脱，术语保留英文"
+    },
+    {
+      "slug": "iron-dad", "core": false,
+      "label": "铁壁暖阳 · 钢铁柔情",
+      "description": "Dependable big-brother persona that absorbs pressure and radiates warmth.",
+      "self": "哥", "user": "宝子", "language": "直白温厚，术语保留英文"
+    },
+    {
+      "slug": "dongbei-yujie", "core": false,
+      "label": "东北魅影·雨姐",
+      "description": "Sharp-tongued Northeast China code overseer. Cuts straight to the bug.",
+      "self": "姐", "user": "老蒯", "language": "中文为主，技术术语保留英文"
+    }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
   },
   "files": [
     "bin/",
+    "config/*.json",
+    "config/*.toml",
     "config/personas/index.json",
     "config/personas/_shared/",
     "config/personas/abyss/",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,10 @@
   },
   "files": [
     "bin/",
-    "config/",
+    "config/personas/index.json",
+    "config/personas/_shared/",
+    "config/personas/abyss/",
+    "config/personas/abyss.md",
     "output-styles/",
     "packs/",
     "skills/",

--- a/test/persona-fetch.test.js
+++ b/test/persona-fetch.test.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const { getCacheDir, isPersonaCached, CACHE_BASE } = require('../bin/lib/persona-fetch');
+
+describe('persona-fetch', () => {
+  test('getCacheDir returns path under ~/.code-abyss/personas/', () => {
+    const dir = getCacheDir('scholar');
+    expect(dir).toBe(path.join(os.homedir(), '.code-abyss', 'personas', 'scholar'));
+  });
+
+  test('isPersonaCached returns false for non-existent slug', () => {
+    expect(isPersonaCached('__nonexistent_test_persona__')).toBe(false);
+  });
+
+  test('CACHE_BASE is under home directory', () => {
+    expect(CACHE_BASE).toContain('.code-abyss');
+    expect(CACHE_BASE).toContain('personas');
+  });
+});

--- a/test/style-registry.test.js
+++ b/test/style-registry.test.js
@@ -175,19 +175,32 @@ describe('persona registry', () => {
     }
   });
 
-  test('单一事实源：index.json 不得重复 card 的 voice/label/description', () => {
+  test('单一事实源：core persona 的 index.json 条目不含 voice/label/description', () => {
     const raw = JSON.parse(
       fs.readFileSync(path.join(projectRoot, 'config', 'personas', 'index.json'), 'utf8')
     );
     for (const entry of raw.personas) {
+      if (entry.core === false) continue;
       ['self', 'user', 'language', 'label', 'description'].forEach((field) => {
         expect(entry[field]).toBeUndefined();
       });
     }
   });
 
-  test('派生值与对应 persona-card.json 严格一致', () => {
-    const personas = listPersonas(projectRoot);
+  test('非核心 persona 的 index.json 条目必须含 snapshot metadata', () => {
+    const raw = JSON.parse(
+      fs.readFileSync(path.join(projectRoot, 'config', 'personas', 'index.json'), 'utf8')
+    );
+    for (const entry of raw.personas) {
+      if (entry.core !== false) continue;
+      ['self', 'user', 'language', 'label', 'description'].forEach((field) => {
+        expect(entry[field]).toBeTruthy();
+      });
+    }
+  });
+
+  test('核心 persona 派生值与对应 persona-card.json 严格一致', () => {
+    const personas = listPersonas(projectRoot).filter(p => p.core !== false);
     for (const p of personas) {
       const card = JSON.parse(
         fs.readFileSync(


### PR DESCRIPTION
## Summary

Only **abyss** ships with the npm package. All other personas (scholar, elder-sister, junior-sister, iron-dad, dongbei-yujie) are fetched from GitHub raw on first use and cached locally.

### Architecture

- **index.json** gains `core`/`remote` model:
  - Core personas: `core: true`, metadata derived from `persona-card.json` at load time
  - Remote personas: `core: false`, snapshot metadata inline for offline selection prompt
  - `remote.base` URL for GitHub raw fetch
- **New `bin/lib/persona-fetch.js`**: HTTPS fetch + cache at `~/.code-abyss/personas/<slug>/`
- **style-registry.js**: path resolution now cache-aware — checks local `config/personas/` first (repo dev mode), falls back to cache dir (npm package mode)
- **select.js**: triggers `ensureRemotePersona()` when non-core persona is selected
- **package.json `files`**: narrowed to only include `abyss` persona + shared behavior + index.json

### User experience

```bash
# Core persona — works offline, no fetch
npx code-abyss -t claude --persona abyss -y

# Remote persona — auto-fetched on first use, cached thereafter
npx code-abyss -t claude --persona scholar -y
# "拉取远程人格 scholar ..."
```

## Test plan
- [x] `npm run verify:skills` — 29 skills pass
- [x] `npm test` — 383 tests pass (21 style-registry + 3 persona-fetch)
- [x] Full cross-combo smoke (all persona × all style) passes in repo dev mode
- [ ] CI green on Node 18/20/22 + smoke install
- [ ] Manual: `npx code-abyss -t claude --persona scholar -y` fetches from GitHub