### PR TITLE
release: v4.7.1 — implement the documented -t flag + abyss enablement docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [4.7.1] - 2026-06-12
+
+> **Patch: the documented install command now works.** `-t` was used everywhere in the docs but never implemented in the parser.
+
+### Fixed
+
+- **`-t` / `-u` short flags implemented.** The README quickstart, site install cards, and CLAUDE.md all used `npx code-abyss -t claude -y`, but the arg parser only matched `--target` — so `-t` was silently ignored, the target stayed unset, and the command fell into the interactive picker (breaking outright under `-y` on a non-TTY). `-t` is now an alias for `--target`, `-u` for `--uninstall`, both reflected in `--help`.
+
+### Changed
+
+- **Quickstart surfaces code-graph enablement.** README + zh-CN README lead with `--with-abyss` (one-shot binary download so the pre-edit hooks work out of the box), document `--with-mcp`, clarify what plain `-y` installs, and add a verify step (`abyss --version`, `abyss index`).
+- **Site install + code-graph sections.** A tip row surfaces `--with-abyss` / `--with-mcp`; the code-graph section shows the SCIP benchmark as a row of precision pills (Go/TS/Python/Rust) instead of a crammed sentence; footer version corrected to v4.7.0.
+
 ## [4.7.0] - 2026-06-12
 
 > **Product-line release.** Code Abyss (the agent integration layer) ships aligned with `abyss` v0.3.3 (the code graph engine) as one product line.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-abyss",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "description": "为 Claude Code / Codex CLI / Gemini CLI / OpenClaw 注入可切换人格、主动执行导向、5种输出风格与30个工程技能（含自我进化炼炉 + 代码关系图智能）",
   "keywords": [
     "claude",


### PR DESCRIPTION
## Patch release

The headline install command in every doc surface (`npx code-abyss -t claude -y`) used `-t`, but the arg parser only matched `--target` — so `-t` was silently ignored and the command fell into the interactive picker (broke outright under `-y` on non-TTY). This patch makes the documented command actually work.

### Fixed
- `-t` / `-u` short flags implemented (alias for `--target` / `--uninstall`), reflected in `--help`.

### Changed (docs/site, since 4.7.0)
- Quickstart leads with `--with-abyss` (one-shot code-graph enable), documents `--with-mcp`, clarifies plain `-y`, adds a verify step.
- Site: `--with-abyss`/`--with-mcp` tip row; code-graph section shows SCIP benchmark as precision pills; footer version → v4.7.0.

### Verification
- 409 tests pass; `-t` parses correctly in `--help` and install flow.