### PR TITLE
release: v4.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [4.7.2] - 2026-06-13
+
+> **Patch: Codex install no longer corrupts `config.toml`.** Codex 0.125+ rejected the hooks schema we generated, breaking `codex` startup outright.
+
+### Fixed
+
+- **Codex hooks now use the array-of-tables schema** (`#49`). Codex 0.125+ deprecated the flat `[hooks.X]` table form; installs produced a `config.toml` that failed to load with `invalid type: map, expected a sequence in hooks`, breaking `codex` startup. `injectCodexHooks` now emits `[[hooks.X]]` + `[[hooks.X.hooks]]` (type/command/timeout/statusMessage), and `stripCodexAbyssIntegration` groups those units for clean uninstall. Idempotent re-runs, stale-path re-anchoring, and non-destructive skip of user-owned hooks are preserved. The `install-hooks.sh` codex branch was updated to match.
+- **Windows `command_windows` override for Codex hooks.** At install time on Windows the installer locates Git Bash (`where bash`, then common install dirs) and emits `command_windows`, so the bash hook scripts run even when Git Bash is not on `PATH`. Omitted on non-Windows.
+
 ## [4.7.1] - 2026-06-12
 
 > **Patch: the documented install command now works.** `-t` was used everywhere in the docs but never implemented in the parser.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "code-abyss",
-  "version": "3.0.0",
+  "version": "4.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "code-abyss",
-      "version": "3.0.0",
+      "version": "4.7.2",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.10.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-abyss",
-  "version": "4.7.1",
+  "version": "4.7.2",
   "description": "为 Claude Code / Codex CLI / Gemini CLI / OpenClaw 注入可切换人格、主动执行导向、5种输出风格与30个工程技能（含自我进化炼炉 + 代码关系图智能）",
   "keywords": [
     "claude",


### PR DESCRIPTION
Patch release. Bumps version to 4.7.2 and adds the CHANGELOG entry for the Codex hooks TOML schema fix (#49, merged in #50).

### Included
- fix(codex): array-of-tables hooks schema (Codex 0.125+) + Windows `command_windows`

No code changes beyond version + CHANGELOG; the fix itself already landed on main via #50.