### PR TITLE
release: v4.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [4.8.2] - 2026-06-25
+
+### Changed
+
+- **abyss hooks are now opt-in.** Default install no longer auto-injects `SessionStart` + `PreToolUse`/`BeforeTool` hooks into Claude / Codex / Gemini settings. The `indexing-code` skill remains available for passive model-driven invocation. Pass `--with-hooks` to restore the previous behavior. Re-installing without `--with-hooks` strips prior marker-tagged entries; user-authored hooks are untouched (marker-based).
+- **Bundled ccstatusline preset compacted to a single line.** Dropped redundant `↑input` / `↓output` / `⊡cached` token fields (already encoded in `session-cost`), `context-length` absolute count (covered by percentage), and `session-clock`. Now shows: `model · context-% · cost · git-root-dir`, separated by U+22EE (⋮).
+
 ## [4.8.1] - 2026-06-19
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-abyss",
-  "version": "4.8.1",
+  "version": "4.8.2",
   "description": "为 Claude Code / Codex CLI / Gemini CLI / OpenClaw 注入可切换人格、主动执行导向、5种输出风格与30个工程技能（含自我进化炼炉 + 代码关系图智能）",
   "keywords": [
     "claude",


### PR DESCRIPTION
## Summary

- **abyss hooks gated behind `--with-hooks`** — default install no longer auto-injects `SessionStart` + `PreToolUse`/`BeforeTool` hooks. Re-install without the flag strips marker-tagged entries; user-authored hooks untouched. Skill-based passive route (`indexing-code`) remains the cleaner default.
- **ccstatusline bundled preset compacted** to single line: `model · context-% · cost · git-root-dir` (⋮ separator). Token triplet + context-length + session-clock dropped as redundant.

## Test plan

- [x] \`npm test\` — 425/425 passed (1 skipped)
- [x] \`npm run verify:skills\` — 30 skills passed
- [ ] CI green across Node 18/20/22 + smoke install on ubuntu/macos/windows × 4 targets