### PR TITLE
fix(hooks): openclaw --with-hooks was a silent no-op

### DIFF
--- a/skills/indexing-code/hooks/common/install-hooks.sh
+++ b/skills/indexing-code/hooks/common/install-hooks.sh
@@ -138,9 +138,17 @@ YAML
     ;;
 
   openclaw)
-    echo "OpenClaw: copy the plugin file to your OpenClaw plugins directory:"
-    echo "  cp ${HOOK_ROOT}/openclaw/plugin.js ~/.openclaw/plugins/abyss-hooks.js"
-    echo "  Then register in your plugin config."
+    # plugin.js resolves its hook scripts via path.join(__dirname, '..', 'common') —
+    # it needs an `openclaw/` dir with a sibling `common/` wherever it lands, so a
+    # flat single-file copy (the old behavior here — and the old printed instruction,
+    # which told users to do the same broken copy manually) silently breaks that
+    # lookup. Mirror the source hooks/ layout instead.
+    PLUGIN_DIR="${HOME}/.openclaw/plugins/abyss-hooks"
+    mkdir -p "$PLUGIN_DIR/openclaw"
+    cp -r "${HOOK_ROOT}/common" "$PLUGIN_DIR/common"
+    cp "${HOOK_ROOT}/openclaw/plugin.js" "$PLUGIN_DIR/openclaw/plugin.js"
+    echo "✓ OpenClaw plugin installed at $PLUGIN_DIR/openclaw/plugin.js"
+    echo "  Register it in your OpenClaw plugin config to enable it."
     ;;
 
   *)

--- a/test/install-hooks-sh.test.js
+++ b/test/install-hooks-sh.test.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const { spawnSync } = require('child_process');
+
+const SCRIPT = path.join(__dirname, '..', 'skills', 'indexing-code', 'hooks', 'common', 'install-hooks.sh');
+
+describe('install-hooks.sh openclaw branch', () => {
+  let tmpHome;
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'code-abyss-hooks-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  test('actually installs the plugin (not just prints instructions)', () => {
+    const r = spawnSync('bash', [SCRIPT, 'openclaw'], {
+      env: { ...process.env, HOME: tmpHome },
+      encoding: 'utf8',
+    });
+    expect(r.status).toBe(0);
+
+    const pluginDir = path.join(tmpHome, '.openclaw', 'plugins', 'abyss-hooks');
+    expect(fs.existsSync(path.join(pluginDir, 'openclaw', 'plugin.js'))).toBe(true);
+    expect(fs.existsSync(path.join(pluginDir, 'common', 'session-init.sh'))).toBe(true);
+    expect(fs.existsSync(path.join(pluginDir, 'common', 'pre-edit-check.sh'))).toBe(true);
+  });
+
+  test('installed plugin.js resolves its hook scripts via the correct relative path (does not silently break on copy)', () => {
+    spawnSync('bash', [SCRIPT, 'openclaw'], { env: { ...process.env, HOME: tmpHome } });
+
+    const pluginPath = path.join(tmpHome, '.openclaw', 'plugins', 'abyss-hooks', 'openclaw', 'plugin.js');
+    const hookDir = path.join(path.dirname(pluginPath), '..', 'common');
+    expect(fs.existsSync(path.join(hookDir, 'session-init.sh'))).toBe(true);
+    expect(fs.existsSync(path.join(hookDir, 'pre-edit-check.sh'))).toBe(true);
+
+    const register = require(pluginPath);
+    expect(typeof register).toBe('function');
+  });
+
+  test('idempotent: running twice does not fail', () => {
+    const first = spawnSync('bash', [SCRIPT, 'openclaw'], { env: { ...process.env, HOME: tmpHome } });
+    const second = spawnSync('bash', [SCRIPT, 'openclaw'], { env: { ...process.env, HOME: tmpHome } });
+    expect(first.status).toBe(0);
+    expect(second.status).toBe(0);
+  });
+});


### PR DESCRIPTION
## What

\`install-hooks.sh\`'s \`openclaw)\` branch only printed manual copy instructions
and never touched disk — every other platform (claude/codex/gemini/pi/hermes)
actually performs the install. \`bin/install.js\`'s \`maybeSpawnInstallHooks()\`
only checks the script's exit code (always 0 for a plain \`echo\`), so it printed
\`hook 已注入 openclaw\` even though nothing was installed.

Per this same file's own comment, code-abyss is the *only* entry point for
openclaw hook injection (abyss CLI deliberately doesn't handle openclaw) — so
this meant \`--with-hooks\` on openclaw silently did nothing for every user.

The old printed instruction was also itself broken: copying \`plugin.js\` alone
to \`~/.openclaw/plugins/abyss-hooks.js\` breaks its
\`path.join(__dirname, '..', 'common')\` hook-script lookup, since it needs an
\`openclaw/\` dir with a sibling \`common/\`, not a flattened loose file.

## Fix

Mirrors hermes's existing pattern: actually \`cp\` into a self-contained plugin
directory (\`~/.openclaw/plugins/abyss-hooks/{openclaw,common}/\`), preserving
the relative directory structure \`plugin.js\` depends on.

## Test plan

- [x] Added \`test/install-hooks-sh.test.js\` (zero coverage existed before —
  how this went unnoticed)
- [x] Verified end-to-end via the real installer (\`--with-hooks\`) and manually
  confirmed the installed \`plugin.js\` requires cleanly and resolves both hook
  scripts
- [x] \`npm test\` — 444 tests (442 passing, 2 skipped)